### PR TITLE
관리자 유저, 회원가입 도메인 통합 테스트 구현

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation group: 'com.auth0', name: 'java-jwt', version: '4.3.0'
 
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'com.h2database:h2'

--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'com.h2database:h2'
 
     implementation "io.springfox:springfox-boot-starter:3.0.0"
     implementation "io.springfox:springfox-swagger-ui:3.0.0"

--- a/admin/src/test/java/com/example/admin/user/SignUpIntegrationTest.java
+++ b/admin/src/test/java/com/example/admin/user/SignUpIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.example.admin.user;
 
 import com.example.admin.user.dto.SignUpRequest;
+import com.example.admin.user.dto.SignUpResponse;
 import com.example.admin.user.service.SignUpService;
 import com.example.core.config._security.encryption.Encryption;
 import com.example.core.errors.ErrorMessage;
 import com.example.core.errors.exception.EmptyDtoRequestException;
+import com.example.core.errors.exception.EmptyPagingDataRequestException;
 import com.example.core.errors.exception.SignUpServiceException;
 import com.example.core.model.user.SignUp;
 import com.example.core.model.user.User;
@@ -15,6 +17,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
@@ -84,5 +89,33 @@ public class SignUpIntegrationTest {
         // Then
         Assertions.assertThrows(EmptyDtoRequestException.class, () ->
                 signUpService.approve(approveDTO));
+    }
+
+    @DisplayName("회원 가입 요청 리스트 조회 테스트 - 성공")
+    @Test
+    void getAllList_Success_Test() {
+        // Given
+        Pageable pageable = PageRequest.of(1, 4);
+
+        // When
+        Page<SignUpResponse.ListDTO> actual = signUpService.getAllList(pageable);
+
+        // Then
+        Assertions.assertEquals(4, actual.getSize());
+        Assertions.assertEquals(6, actual.getTotalElements());
+        Assertions.assertEquals("senior", actual.getContent().get(0).getUsername());
+        Assertions.assertEquals("junior", actual.getContent().get(1).getUsername());
+    }
+
+    @DisplayName("회원 가입 요청 리스트 조회 테스트 - 실패 [빈 페이징 데이터 전달]")
+    @Test
+    void getAllList_Failure_Test_GivenEmptyPageableData() {
+        // Given
+        Pageable pageable = null;
+
+        // When
+        // Then
+        Assertions.assertThrows(EmptyPagingDataRequestException.class, () ->
+                signUpService.getAllList(pageable));
     }
 }

--- a/admin/src/test/java/com/example/admin/user/SignUpIntegrationTest.java
+++ b/admin/src/test/java/com/example/admin/user/SignUpIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.example.admin.user;
+
+import com.example.admin.user.dto.SignUpRequest;
+import com.example.admin.user.service.SignUpService;
+import com.example.core.config._security.encryption.Encryption;
+import com.example.core.errors.ErrorMessage;
+import com.example.core.errors.exception.EmptyDtoRequestException;
+import com.example.core.errors.exception.SignUpServiceException;
+import com.example.core.model.user.SignUp;
+import com.example.core.model.user.User;
+import com.example.core.repository.user.SignUpRepository;
+import com.example.core.repository.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Optional;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class SignUpIntegrationTest {
+
+    @Autowired
+    private SignUpService signUpService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private SignUpRepository signUpRepository;
+
+    @Autowired
+    private Encryption encryption;
+
+    @DisplayName("회원 가입 요청 승인 테스트 - 성공")
+    @Test
+    void approve_Success_Test() {
+        // Given
+        final String email = "test7@test.com";
+        final String encryptedEmail = encryption.encrypt(email);
+
+        SignUpRequest.ApproveDTO approveDTO =
+                new SignUpRequest.ApproveDTO(email);
+
+        // When
+        signUpService.approve(approveDTO);
+        Optional<SignUp> signUpOptional = signUpRepository.findByEmail(encryptedEmail);
+        Optional<User> userOptional = userRepository.findByEmail(encryptedEmail);
+
+        // Then
+        Assertions.assertTrue(signUpOptional.isEmpty());
+        Assertions.assertTrue(userOptional.isPresent());
+    }
+
+    @DisplayName("회원 가입 요청 승인 테스트 - 실패 [유효하지 않은 Email 요청]")
+    @Test
+    void approve_Failure_Test_GivenInvalidEmail() {
+        // Given
+        SignUpRequest.ApproveDTO approveDTO =
+                new SignUpRequest.ApproveDTO("invalid@email.com");
+
+        // When
+        // Then
+        Assertions.assertThrows(SignUpServiceException.class, () ->
+                signUpService.approve(approveDTO));
+
+        try {
+            signUpService.approve(approveDTO);
+        } catch (SignUpServiceException exception) {
+            Assertions.assertEquals(ErrorMessage.NOT_FOUND_SIGNUP, exception.getMessage());
+        }
+    }
+
+    @DisplayName("회원 가입 요청 승인 테스트 - 실패 [비어있는 DTO 요청]")
+    @Test
+    void approve_Failure_Test_GivenEmptyDTO() {
+        // Given
+        SignUpRequest.ApproveDTO approveDTO = null;
+
+        // When
+        // Then
+        Assertions.assertThrows(EmptyDtoRequestException.class, () ->
+                signUpService.approve(approveDTO));
+    }
+}

--- a/admin/src/test/java/com/example/admin/user/UserIntegrationTest.java
+++ b/admin/src/test/java/com/example/admin/user/UserIntegrationTest.java
@@ -1,0 +1,49 @@
+package com.example.admin.user;
+
+import com.example.admin.user.dto.UserResponse;
+import com.example.admin.user.service.UserService;
+import com.example.core.errors.exception.EmptyPagingDataRequestException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application-test.yml")
+public class UserIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @DisplayName("전체 유저 정보 조회 통합 테스트 - 성공")
+    @Test
+    void getAllList_Success_Test() {
+        // Given
+        Pageable pageable = PageRequest.of(1, 4);
+
+        // When
+        Page<UserResponse.ListDTO> actual = userService.getAllUsers(pageable);
+
+        // Then
+        Assertions.assertEquals(4, actual.getSize());
+        Assertions.assertEquals("senior", actual.getContent().get(0).getUsername());
+        Assertions.assertEquals("junior", actual.getContent().get(1).getUsername());
+    }
+
+    @DisplayName("전체 유저 정보 조회 통합 테스트 - 실패 [빈 페이징 데이터 전달]")
+    @Test
+    void getAllList_Failure_Test_GivenEmptyPageableData() {
+        // Given
+        Pageable pageable = null;
+
+        // When
+        // Then
+        Assertions.assertThrows(EmptyPagingDataRequestException.class, () ->
+                userService.getAllUsers(pageable));
+    }
+}


### PR DESCRIPTION
- #88 
- #89 

![image](https://github.com/FastCampus-Mini5/BE_server/assets/96504592/b7d7c80b-7ec6-416c-add9-c306fadad484)
![image](https://github.com/FastCampus-Mini5/BE_server/assets/96504592/31949525-a1a8-4213-9a2f-ad1c57a4da73)

resolved: #88 #89 